### PR TITLE
Installation/CentOS: Foreman now requires SCLorg SIG repo

### DIFF
--- a/installation/01_requirements.md
+++ b/installation/01_requirements.md
@@ -7,6 +7,7 @@
  * optionally: Puppetlabs Repository
 * CentOS, Scientific Linux, Oracle Linux 6 & 7
  * EPEL repository
+ * SCLorg SIG repository
  * optionally: Puppetlabs Repository
 * Fedora (not recommended) 
 * Debian 7


### PR DESCRIPTION
See https://github.com/theforeman/theforeman.org/pull/618

Signed-off-by: Julien Pivotto roidelapluie@inuits.eu
