### PR TITLE
Remove 'Puppet - in the Foreman way'

### DIFF
--- a/configmanagement/02_puppet.md
+++ b/configmanagement/02_puppet.md
@@ -361,7 +361,7 @@ We will have a deeper look into this instead of configuring the "Puppetrun" feat
 * Configuration of:
  * Foreman
  * Smart Proxy
- * Puppet - in the Foreman way
+ * Puppet
  * Depending and managed services
 
 ~~~SECTION:notes~~~


### PR DESCRIPTION
The Foreman's puppet-puppet module is now generic and does not require
Foreman (I know it because I made that improvement).

It is okay to keep the full explanation in the handout as it

Signed-off-by: Julien Pivotto roidelapluie@inuits.eu
